### PR TITLE
DIV-3956 - initial configuration for divorce alerts

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -19,7 +19,7 @@ def product = 'div'
 onMaster {
   sharedInfrastructurePipeline(product, environment.nonProdName, subscription.nonProdName)
   //sharedInfrastructurePipeline(product, environment.demoName, subscription.nonProdName)
-  sharedInfrastructurePipeline(product, environment.prodName, subscription.prodName)
+  //sharedInfrastructurePipeline(product, environment.prodName, subscription.prodName)
 }
 /*
 onDemo {

--- a/action-groups.tf
+++ b/action-groups.tf
@@ -11,7 +11,7 @@ module "divorce-action-group" {
   env      = "${var.env}"
 
   resourcegroup_name     = "${azurerm_resource_group.rg.name}"
-  action_group_name      = "Divorce Support"
+  action_group_name      = "div-support"
   short_name             = "Div Support"
   email_receiver_name    = "Divorce Support Mailing List"
   email_receiver_address = "${data.azurerm_key_vault_secret.divorce_support_email_secret.value}"

--- a/action-groups.tf
+++ b/action-groups.tf
@@ -1,0 +1,18 @@
+// Divorce Alerts Action Groups
+
+data "azurerm_key_vault_secret" "divorce_support_email_secret" {
+  name      = "divorce-support-email"
+  vault_uri = "${data.azurerm_key_vault.div_key_vault.vault_uri}"
+}
+
+module "divorce-action-group" {
+  source   = "git@github.com:hmcts/cnp-module-action-group"
+  location = "global"
+  env      = "${var.env}"
+
+  resourcegroup_name     = "${azurerm_resource_group.rg.name}"
+  action_group_name      = "Divorce Support"
+  short_name             = "Div Support"
+  email_receiver_name    = "Divorce Support Mailing List"
+  email_receiver_address = "${data.azurerm_key_vault_secret.divorce_support_email_secret.value}"
+}

--- a/alerts.tf
+++ b/alerts.tf
@@ -1,4 +1,4 @@
-module "div-${var.env}-alert" {
+module "div-bad-requests-alert" {
   source = "git@github.com:hmcts/cnp-module-metric-alert"
   location = "${var.location}"
 

--- a/alerts.tf
+++ b/alerts.tf
@@ -13,7 +13,7 @@ module "div-bad-requests-alert" {
   severity_level = "2"
   action_group_name = "Divroce Support"
   trigger_threshold_operator = "GreaterThan"
-  trigger_threshold = 5
+  trigger_threshold = 1
   resourcegroup_name = "${azurerm_resource_group.rg.name}"
 }
 

--- a/alerts.tf
+++ b/alerts.tf
@@ -4,7 +4,7 @@ module "div-bad-requests-alert" {
 
   app_insights_name = "div-${var.env}"
 
-  alert_name = "Bad requests (400 error code) in div-${var.env}"
+  alert_name = "bad-requests"
   alert_desc = "Found HTTP requests with 400 error response code (bad request) in div-${var.env}."
   app_insights_query = "requests | where resultCode == \"400\""
   custom_email_subject = "Alert: bad requests in div-${var.env}"

--- a/alerts.tf
+++ b/alerts.tf
@@ -4,10 +4,29 @@ module "div-bad-requests-alert" {
 
   app_insights_name = "div-${var.env}"
 
-  alert_name = "bad-requests"
+  alert_name = "div-bad-requests"
   alert_desc = "Found HTTP requests with 400 error response code (bad request) in div-${var.env}."
   app_insights_query = "requests | where resultCode == \"400\""
   custom_email_subject = "Alert: bad requests in div-${var.env}"
+  frequency_in_minutes = 5
+  time_window_in_minutes = 5
+  severity_level = "2"
+  action_group_name = "Divroce Support"
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold = 5
+  resourcegroup_name = "${azurerm_resource_group.rg.name}"
+}
+
+module "div-server-errors-alert" {
+  source = "git@github.com:hmcts/cnp-module-metric-alert"
+  location = "${var.location}"
+
+  app_insights_name = "div-${var.env}"
+
+  alert_name = "div-server-errors"
+  alert_desc = "Found HTTP requests with 400 error response code (bad request) in div-${var.env}."
+  app_insights_query = "requests | where resultCode startswith \"5\"  | where name !contains \"/health\""
+  custom_email_subject = "Alert: server errors in div-${var.env}"
   frequency_in_minutes = 5
   time_window_in_minutes = 5
   severity_level = "2"

--- a/alerts.tf
+++ b/alerts.tf
@@ -35,3 +35,22 @@ module "div-server-errors-alert" {
   trigger_threshold = 5
   resourcegroup_name = "${azurerm_resource_group.rg.name}"
 }
+
+module "div-fe-performance-alert" {
+  source = "git@github.com:hmcts/cnp-module-metric-alert"
+  location = "${var.location}"
+
+  app_insights_name = "div-${var.env}"
+
+  alert_name = "div-fe-performance-alert"
+  alert_desc = "Web pages took longer than 10 seconds to load in div-${var.env}."
+  app_insights_query = "requests | where url !contains \"/health\" | where success == \"True\" | where duration > 10000 | where cloud_RoleName in (\"div-pfe\", \"div-rfe\", \"div-dn\")"
+  custom_email_subject = "Alert: performance errors in div-${var.env}"
+  frequency_in_minutes = 5
+  time_window_in_minutes = 5
+  severity_level = "2"
+  action_group_name = "Divroce Support"
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold = 5
+  resourcegroup_name = "${azurerm_resource_group.rg.name}"
+}

--- a/alerts.tf
+++ b/alerts.tf
@@ -5,13 +5,13 @@ module "div-bad-requests-alert" {
   app_insights_name = "div-${var.env}"
 
   alert_name = "div-bad-requests"
-  alert_desc = "Found HTTP requests with 400 error response code (bad request) in div-${var.env}."
-  app_insights_query = "requests | where resultCode == \"400\""
+  alert_desc = "Found HTTP requests with 400 or 422 error response codes (bad request) in div-${var.env}."
+  app_insights_query = "requests | where resultCode in (\"400\", \"422\")"
   custom_email_subject = "Alert: bad requests in div-${var.env}"
   frequency_in_minutes = 5
   time_window_in_minutes = 5
   severity_level = "2"
-  action_group_name = "Divroce Support"
+  action_group_name = "Divorce Support"
   trigger_threshold_operator = "GreaterThan"
   trigger_threshold = 1
   resourcegroup_name = "${azurerm_resource_group.rg.name}"
@@ -30,9 +30,9 @@ module "div-server-errors-alert" {
   frequency_in_minutes = 5
   time_window_in_minutes = 5
   severity_level = "2"
-  action_group_name = "Divroce Support"
+  action_group_name = "Divorce Support"
   trigger_threshold_operator = "GreaterThan"
-  trigger_threshold = 5
+  trigger_threshold = 20
   resourcegroup_name = "${azurerm_resource_group.rg.name}"
 }
 
@@ -49,7 +49,7 @@ module "div-fe-performance-alert" {
   frequency_in_minutes = 5
   time_window_in_minutes = 5
   severity_level = "2"
-  action_group_name = "Divroce Support"
+  action_group_name = "Divorce Support"
   trigger_threshold_operator = "GreaterThan"
   trigger_threshold = 5
   resourcegroup_name = "${azurerm_resource_group.rg.name}"

--- a/alerts.tf
+++ b/alerts.tf
@@ -1,0 +1,18 @@
+module "div-${var.env}-alert" {
+  source = "git@github.com:hmcts/cnp-module-metric-alert"
+  location = "${var.location}"
+
+  app_insights_name = "div-${var.env}"
+
+  alert_name = "Bad requests (400 error code) in div-${var.env}"
+  alert_desc = "Found HTTP requests with 400 error response code (bad request) in div-${var.env}."
+  app_insights_query = "requests | where resultCode == \"400\""
+  custom_email_subject = "Alert: bad requests in div-${var.env}"
+  frequency_in_minutes = 5
+  time_window_in_minutes = 5
+  severity_level = "2"
+  action_group_name = "Divroce Support"
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold = 5
+  resourcegroup_name = "${azurerm_resource_group.rg.name}"
+}

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -18,3 +18,13 @@ data "azurerm_key_vault" "div_key_vault" {
   name                = "div-${var.env}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
 }
+
+data "azurerm_key_vault" "creator_access_policy" {
+  name                = "div-${var.env}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
+}
+
+data "azurerm_key_vault" "product_team_access_policy" {
+  name                = "div-${var.env}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
+}

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -12,3 +12,8 @@ module "div-vault" {
 output "vaultName" {
   value = "${module.div-vault.key_vault_name}"
 }
+
+data "azurerm_key_vault" "div_key_vault" {
+  name                = "div-${var.env}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
+}

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -7,6 +7,7 @@ module "div-vault" {
   object_id               = "${var.jenkins_AAD_objectId}"
   resource_group_name     = "${azurerm_resource_group.rg.name}"
   product_group_object_id = "3450807e-5248-4053-944f-9df59dda50b9"
+  common_tags             = "${var.common_tags}"
 }
 
 output "vaultName" {

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -18,13 +18,3 @@ data "azurerm_key_vault" "div_key_vault" {
   name                = "div-${var.env}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
 }
-
-data "azurerm_key_vault" "creator_access_policy" {
-  name                = "div-${var.env}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-}
-
-data "azurerm_key_vault" "product_team_access_policy" {
-  name                = "div-${var.env}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "1.19.0"
+  version = "1.22.1"
 }
 
 locals {

--- a/sandbox.tfvars
+++ b/sandbox.tfvars
@@ -1,11 +1,11 @@
 aos_external_hostname = "div-rfe.sandbox.platform.hmcts.net"
 
-aos_external_cert_name = "star-sandbox"
+aos_external_cert_name = "STAR-sandbox-platform-hmcts-net"
 
 dn_external_hostname = "div-dn.sandbox.platform.hmcts.net"
 
 dn_internal_hostname = "div-dn-sandbox.service.core-compute-sandbox.internal"
 
-dn_external_cert_name = "star-sandbox"
+dn_external_cert_name = "STAR-sandbox-platform-hmcts-net"
 
 external_cert_vault_uri = "https://infra-vault-sandbox.vault.azure.net/"

--- a/sandbox.tfvars
+++ b/sandbox.tfvars
@@ -1,0 +1,11 @@
+aos_external_hostname = "div-rfe.sandbox.platform.hmcts.net"
+
+aos_external_cert_name = "star-sandbox"
+
+dn_external_hostname = "div-dn.sandbox.platform.hmcts.net"
+
+dn_internal_hostname = "div-dn-sandbox.service.core-compute-sandbox.internal"
+
+dn_external_cert_name = "star-sandbox"
+
+external_cert_vault_uri = "https://infra-vault-nonprod.vault.azure.net/"

--- a/sandbox.tfvars
+++ b/sandbox.tfvars
@@ -8,4 +8,4 @@ dn_internal_hostname = "div-dn-sandbox.service.core-compute-sandbox.internal"
 
 dn_external_cert_name = "star-sandbox"
 
-external_cert_vault_uri = "https://infra-vault-nonprod.vault.azure.net/"
+external_cert_vault_uri = "https://infra-vault-sandbox.vault.azure.net/"


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

DIV-3956

### Change description ###

0) Updated the azurerm version to the latest version
1) Created an action group, which is set up with the divorce support mailing list
2) Created an alert to trigger an email if any 400 HTTP errors have occur 
3) Created an alert to trigger an email if any 5xx HTTP errors occur (excluding /health)
4) Created an alert to trigger an email if any FE page takes longer than 10 seconds to render
5) Added sandbox vars file 

We may have to adjust the values above over time (trigger threshold etc) depending on how reliable the logging is

Reference links:

* https://github.com/hmcts/cmc-shared-infrastructure
* https://github.com/hmcts/cnp-module-action-group
* https://github.com/hmcts/cnp-module-metric-alert

Thanks @alexwakeman for the initial implementation

You can check what the alerts look like in Azure Portal -> div-sandbox (application insights) -> Alerts

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
