### PR TITLE
Don't alert on payments update

### DIFF
--- a/alerts.tf
+++ b/alerts.tf
@@ -6,7 +6,7 @@ module "div-bad-requests-alert" {
 
   alert_name = "div-bad-requests"
   alert_desc = "Found HTTP requests with 400 or 422 error response codes (bad request) in div-${var.env}."
-  app_insights_query = "requests | where resultCode in (\"400\", \"422\")" and url !contains "payment-update" and url !contains "paymentMade"
+  app_insights_query = "requests | where resultCode in (\"400\", \"422\") and url !contains \"payment-update\" and url !contains \"paymentMade\""
   custom_email_subject = "Alert: bad requests in div-${var.env}"
   frequency_in_minutes = 5
   time_window_in_minutes = 5

--- a/alerts.tf
+++ b/alerts.tf
@@ -6,7 +6,7 @@ module "div-bad-requests-alert" {
 
   alert_name = "div-bad-requests"
   alert_desc = "Found HTTP requests with 400 or 422 error response codes (bad request) in div-${var.env}."
-  app_insights_query = "requests | where resultCode in (\"400\", \"422\")"
+  app_insights_query = "requests | where resultCode in (\"400\", \"422\")" and url !contains "payment-update" and url !contains "paymentMade"
   custom_email_subject = "Alert: bad requests in div-${var.env}"
   frequency_in_minutes = 5
   time_window_in_minutes = 5


### PR DESCRIPTION
Getting spammed with alerts due to a bug on payment service callback side. This does not impact users as they have successfully progressed the case already. For legitimate errors we may need to wait for a seviceNow ticket although ideally the paynentUpdate endpoint will catch the edge payment failed to update cases.

Ignoring paynentMade event trigger as well since that is the dependent call on the paymebtUpdate. This does mean the frontend payment update trigger will not alert, however the parent call for that on PFE which is ipdateCase should still alert, so catches any actual issues related to payment made not occurring through the payment-update callback endpoint.