### PR TITLE
DIV-4951 Add filter to results to avoid picking up errors from Jenkins nightly build

### DIFF
--- a/alerts.tf
+++ b/alerts.tf
@@ -26,7 +26,7 @@ module "div-server-errors-alert" {
 
   alert_name = "div-server-errors"
   alert_desc = "Found HTTP requests with 500 error response code (bad request) in div-${var.env}."
-  app_insights_query = "requests | where resultCode startswith '5'  | where name !contains '/health' | where datetime_diff('hour', timestamp, startofday(timestamp)) !between (2 .. 5)"
+  app_insights_query = "requests | where resultCode startswith '5'  | where name !contains '/health' | where datetime_diff('hour', timestamp, startofday(timestamp)) !between (2 .. 5) or url !contains '-aat'"
   custom_email_subject = "Alert: server errors in div-${var.env}"
   frequency_in_minutes = 5
   time_window_in_minutes = 5

--- a/alerts.tf
+++ b/alerts.tf
@@ -6,7 +6,7 @@ module "div-bad-requests-alert" {
 
   alert_name = "div-bad-requests"
   alert_desc = "Found HTTP requests with 400 or 422 error response codes (bad request) in div-${var.env}."
-  app_insights_query = "requests | where resultCode in (\"400\", \"422\")"
+  app_insights_query = "requests | where resultCode in ('400', '422')"
   custom_email_subject = "Alert: bad requests in div-${var.env}"
   frequency_in_minutes = 5
   time_window_in_minutes = 5
@@ -25,8 +25,8 @@ module "div-server-errors-alert" {
   app_insights_name = "div-${var.env}"
 
   alert_name = "div-server-errors"
-  alert_desc = "Found HTTP requests with 400 error response code (bad request) in div-${var.env}."
-  app_insights_query = "requests | where resultCode startswith \"5\"  | where name !contains \"/health\""
+  alert_desc = "Found HTTP requests with 500 error response code (bad request) in div-${var.env}."
+  app_insights_query = "requests | where resultCode startswith '5'  | where name !contains '/health' | where datetime_diff('hour', timestamp, startofday(timestamp)) !between (2 .. 5)"
   custom_email_subject = "Alert: server errors in div-${var.env}"
   frequency_in_minutes = 5
   time_window_in_minutes = 5
@@ -45,7 +45,7 @@ module "div-fe-performance-alert" {
 
   alert_name = "div-fe-performance-alert"
   alert_desc = "Web pages took longer than 10 seconds to load in div-${var.env}."
-  app_insights_query = "requests | where url !contains \"/health\" | where success == \"True\" | where duration > 10000 | where cloud_RoleName in (\"div-pfe\", \"div-rfe\", \"div-dn\")"
+  app_insights_query = "requests | where url !contains '/health' | where success == 'True' | where duration > 10000 | where cloud_RoleName in ('div-pfe', 'div-rfe', 'div-dn')"
   custom_email_subject = "Alert: performance errors in div-${var.env}"
   frequency_in_minutes = 5
   time_window_in_minutes = 5


### PR DESCRIPTION
[Fix erroneous email alerts and errors on AAT Azure](https://tools.hmcts.net/jira/browse/DIV-4951)

This filters out errors caused by nightly Jenkins run, specifically OWASP Zap crawler / pen-testing tool. See ticket for more info. 