### PR TITLE
DIV: Creating new alert for bulk print misconfiguration

### DIFF
--- a/alerts.tf
+++ b/alerts.tf
@@ -94,3 +94,23 @@ module "div-data-extraction-alert" {
   resourcegroup_name = "${azurerm_resource_group.rg.name}"
   enabled = "${var.env == "prod" || var.env == "aat"}"
 }
+
+module "div-bulk-print-config-errors-alert" {
+  source = "git@github.com:hmcts/cnp-module-metric-alert"
+  location = "${var.location}"
+
+  app_insights_name = "div-${var.env}"
+
+  alert_name = "div-bulk-print-config-errors-alert"
+  alert_desc = "Logs indicate that the bulk print task has been misconfigured in div-${var.env}."
+  app_insights_query = "traces | where message startswith 'Bulk print for case ' and message has 'is misconfigured.'"
+  custom_email_subject = "Alert: Bulk print task seems to be misconfigured in div-${var.env}"
+  frequency_in_minutes = 720
+  time_window_in_minutes = 1440
+  severity_level = "2"
+  action_group_name = "div-support"
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold = 0
+  resourcegroup_name = "${azurerm_resource_group.rg.name}"
+  enabled = "${var.env == "prod" || var.env == "aat"}"
+}


### PR DESCRIPTION
### Change description ###
We want to be alerted when and if a bulk print task is misconfigured as that will mean documents will not be printed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
