### PR TITLE
create new managed identity in correct subscription

### DIFF
--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,14 +1,15 @@
 module "div-vault" {
-  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
-  name                    = "${var.product}-${var.env}"
-  product                 = var.product
-  env                     = var.env
-  tenant_id               = var.tenant_id
-  object_id               = var.jenkins_AAD_objectId
-  resource_group_name     = azurerm_resource_group.rg.name
-  product_group_name      = "dcd_divorce"
-  common_tags             = var.common_tags
+  source                     = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  name                       = "${var.product}-${var.env}"
+  product                    = var.product
+  env                        = var.env
+  tenant_id                  = var.tenant_id
+  object_id                  = var.jenkins_AAD_objectId
+  resource_group_name        = azurerm_resource_group.rg.name
+  product_group_name         = "dcd_divorce"
+  common_tags                = var.common_tags
   managed_identity_object_id = var.managed_identity_object_id
+  create_managed_identity    = true
 }
 
 output "vaultName" {


### PR DESCRIPTION
Necessary for work to move to Workload Identity

Run: https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_d_to_i%2Fdiv-shared-infrastructure/detail/PR-86/1/pipeline

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
